### PR TITLE
Updated MySQL Command to have settings for Sush-E Databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
             MYSQL_USER: mysql
             MYSQL_PASSWORD: mysql
             MYSQL_DATABASE: sushe
+        command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1
 
     rabbitmq-data:
         image: busybox


### PR DESCRIPTION
Added the UTF 8 switches and lower case table names to the docker command for MySQL to allow Sush-E to properly connect to the database.